### PR TITLE
Permit to specify WaveFormatType when creating Writer

### DIFF
--- a/example/writing.go
+++ b/example/writing.go
@@ -15,10 +15,11 @@ func main() {
 		panic(err)
 	}
 	param := wave.WriterParam{
-		Out:           f,
-		Channel:       1,
-		SampleRate:    44100,
-		BitsPerSample: 16,
+		Out:            f,
+		WaveFormatType: 1,
+		Channel:        1,
+		SampleRate:     44100,
+		BitsPerSample:  16,
 	}
 
 	w, err := wave.NewWriter(param)

--- a/writer.go
+++ b/writer.go
@@ -8,10 +8,11 @@ import (
 )
 
 type WriterParam struct {
-	Out           io.WriteCloser
-	Channel       int
-	SampleRate    int
-	BitsPerSample int
+	Out            io.WriteCloser
+	WaveFormatType int
+	Channel        int
+	SampleRate     int
+	BitsPerSample  int
 }
 
 type Writer struct {
@@ -42,7 +43,7 @@ func NewWriter(param WriterParam) (*Writer, error) {
 		Size: uint32(fmtChunkSize),
 	}
 	w.fmtChunk.Data = &WavFmtChunkData{
-		WaveFormatType: uint16(1), // PCM
+		WaveFormatType: uint16(param.WaveFormatType),
 		Channel:        uint16(param.Channel),
 		SamplesPerSec:  uint32(param.SampleRate),
 		BytesPerSec:    samplesPerSec,


### PR DESCRIPTION
Hi, currently, WaveFormatType is hardcoded as 1 (PCM) when the Writer is created.
It would be nice to be able to set it to a specific value (I tested generating mu-law (Type 7) wav files and it worked).

